### PR TITLE
Add a note about Wii guitars and whammy bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Make sure you **set “Device Class” to “Guitar”.**
 | L1 | ![Orange Fret](images/btns/gtrs/of.png "Orange Fret") | ![Orange Fret](images/btns/gtrs/of.png "Orange Fret") |
 | D-Pad: Up | ![Strumbar Up](images/btns/gtrs/sbu.png "Strumbar Up") | ![Strumbar Up](images/btns/gtrs/sbu.png "Strumbar Up") |
 | D-Pad: Down | ![Strumbar Down](images/btns/gtrs/sbd.png "Strumbar Down") | ![Strumbar Down](images/btns/gtrs/sbd.png "Strumbar Down") |
-| Right Stick: <br/> Left/Right | ![Whammy Bar](images/btns/gtrs/wb.png "Whammy Bar") | ![Whammy Bar](images/btns/gtrs/wb.png "Whammy Bar") |
+| Right Stick: <br/> Left/Right <br/> (ignore Left on some Wii guitars) | ![Whammy Bar](images/btns/gtrs/wb.png "Whammy Bar") | ![Whammy Bar](images/btns/gtrs/wb.png "Whammy Bar") |
 | Right Stick: <br/> Up/Down <br/> (PS3/PS4/Wii guitars only) | ![Effects Switch](images/btns/gtrs/fx.png "Effects Switch") | |
 | L2 <br/> (Xbox 360 guitars only) | ![Effects Switch](images/btns/gtrs/fx.png "Effects Switch") | |
 | R1 | ![Tilt](images/btns/gtrs/ts.png "Tilt") | Does not work |


### PR DESCRIPTION
After experimentation with my Wiimote and GH5 Genericaster setup on Linux, I've determined that it works fine if you bind the whammy bar to right stick right, specifically. Left goes unused but doesn't seem to affect gameplay.

This particular Wiitar's whammy bar shows up as an axis which only provides positive values under Linux's joystick API, and which has a limited range of mostly-positive values under evdev and SDL2. In both of those cases it isn't possible to bind RPCS3 to the negative values as they never cross the deadzone threshold and would be more or less useless anyway.

Under Windows with WiitarThing this doesn't matter, the default mappings work out of the box, but this note would've saved me hours of fiddling and reading Linux kernel source (lmao yes I went a little too deep), so I aim to pass it along :)